### PR TITLE
Add proper parameter support for gen_png + Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,20 @@ When submitting PRs keep the following in mind please:
 
 - only submit SVGs.
 - don't have spaces in your file names. Use snake_case or camelCase instead.
+- only submit SVGs with the file ending `.svg`. Not `.SVG` or `.sVg`
+
+## Generating PNGs 
+If you want to generate PNGs from the SVGs, you can use the `gen_png.py` script.
+
+### Dependencies
+- Python 3.9 - To run the script.
+- Inkscape - Used to generate the PNGs. Needs to be located in PATH.
+- (Optional) git - Can be used to automatically add a new commit with the generated PNGs.
+
+### Usage
+gen_png.py [OPTION]
+
+-h, --help                      Shows this help message.
+-a, --all                       Regenerates all PNGs.
+-s, --specific [FILENAME]...    Regenerate the PNGs for each FILENAME in the "svg" folder. The '.svg' suffix is optional.
+-g, --git                       Regenerates all PNGs and creates a git commit for them. Requires 'git' to be installed and located in PATH.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ If you want to generate PNGs from the SVGs, you can use the `gen_png.py` script.
 - (Optional) git - Can be used to automatically add a new commit with the generated PNGs.
 
 ### Usage
+```
 gen_png.py [OPTION]
 
 -h, --help                      Shows this help message.
 -a, --all                       Regenerates all PNGs.
 -s, --specific [FILENAME]...    Regenerate the PNGs for each FILENAME in the "svg" folder. The '.svg' suffix is optional.
 -g, --git                       Regenerates all PNGs and creates a git commit for them. Requires 'git' to be installed and located in PATH.
+```

--- a/gen_png.py
+++ b/gen_png.py
@@ -22,7 +22,8 @@ import ntpath
 import subprocess
 import sys
 import os
-# Dependencies: grep, git, inkscape, python 3.9
+import platform
+# Dependencies: (optional) git, inkscape, python 3.9
 
 
 # deletes raster graphics with given name
@@ -34,6 +35,7 @@ def delete_graphics(name):
 
 # rasters SVGs via Inkscape
 def raster_graphics(files):
+    # TODO: make this adjustable via option/parameter
     sizes = [72, 512, 1024]
     frogs = len(files)-1
     for f in files:
@@ -70,22 +72,40 @@ def create_tag():
     # create new tag
     stream = os.popen('git tag auto-v'+str(len(tags))) 
     print(stream.read())
+    
+# print help message
+def print_help():
+    print("gen_png.py [OPTION]")
+    print("")
+    print("-h, --help                       Shows this help message.")
+    print("-a, --all                        Regenerates all PNGs.")
+    print("-s, --specific [FILENAME]...     Regenerate the PNGs for each FILENAME in the \"svg\" folder. The '.svg' suffix is optional.")
+    print("-g, --git                        Regenerates all PNGs and creates a git commit for them. Requires 'git' to be installed and located in PATH.")
+    
 # -------------------------------------------------------------------------------------------------------------------------#
 # main section
 #
 files = list()
-if len(sys.argv) == 1:
-    print("Help text missing!")
+# if there are no arguments (or help parameter was specified), print help and exit
+if len(sys.argv) == 1 or sys.argv[1] == '-h' or sys.argv[1] == '--help':
+    print_help()
     exit(1)
-elif sys.argv[1] == 'git':
+# if "git" parameter was specified, regenerate since last tag + create git commit
+elif sys.argv[1] == '-g' or sys.argv[1] == '--git':
     # get modified, added, renamed, deleted SVGs since last tag
-    stream = os.popen('git diff --name-status $(git describe --tags --abbrev=0 --match "auto-v*") HEAD | grep svg/')
+    # call this on windows a) with PS for the $() and b) replace grep with PS' equivalent
+    gitCommand = 'git diff --name-status $(git describe --tags --abbrev=0 --match "auto-v*") HEAD'
+    if sys.platform == "win32":
+        os.environ["COMSPEC"] = 'powershell'
+        stream = os.popen(gitCommand + ' | Select-String svg/')
+    else:
+        stream = os.popen(gitCommand + ' | grep svg/')
     output = stream.read()
     files = output.split('\n')
     files.remove('')
 
     if len(files) == 0:
-        print('nothing to do!')
+        print('No SVGs to regenerate!')
         exit()
     additions = [s.removeprefix('A\t') for s in files if 'A\t' in s]
     modifications = [s.removeprefix('M\t') for s in files if 'M\t' in s]
@@ -114,13 +134,23 @@ elif sys.argv[1] == 'git':
     # commit and tag
     git_commit_raster()
     create_tag()
-else:
-    if sys.argv[1] == 'all':
-        files = [f for f in glob.glob("svg/**/*.svg", recursive=True)]
-    else:
-        for f in sys.argv:
-            f = f.removeprefix('svg/').removesuffix('.svg')
-            if os.path.exists("svg/"+f+".svg"):
-                files.append("svg/"+f+".svg")
+# if "all" parameter was specified, raster all svgs including subfolders
+elif sys.argv[1] == '-a' or sys.argv[1] == '--all':
+    files = [f for f in glob.glob("svg/**/*.svg", recursive=True)]
     raster_graphics(files)
+# if "specific" parameter was specified, only render those
+elif sys.argv[1] == '-s' or sys.argv[1] == '--specific':
+    if len(sys.argv) == 2:
+        print("Please specify at least one file!")
+        exit(1)
 
+    for f in sys.argv:
+        f = f.removeprefix('svg/').removesuffix('.svg')
+        if os.path.exists("svg/"+f+".svg"):
+            files.append("svg/"+f+".svg")
+    raster_graphics(files)
+# unknown option
+else:
+    print("Unknown option!")
+    print("Try 'gen_png.py --help' for more information.")
+    


### PR DESCRIPTION
Changes how the gen_png python script handles parameters.
Usage is now as follows:
```
-h, --help                      Shows this help message.
-a, --all                       Regenerates all PNGs.
-s, --specific [FILENAME]...    Regenerate the PNGs for each FILENAME in the "svg" folder. The '.svg' suffix is optional.
-g, --git                       Regenerates all PNGs and creates a git commit for them. Requires 'git' to be installed and located in PATH.
```
No parameter / unknown parameters are handled.

Support for Windows with the --git option also was introduced. 