### PR TITLE
Add CI for testing svg's

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,6 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Install Inkscape
-        run: sudo apt install inkscape
-
       - name: Check SVG validity
         run: |
           # Enables globstar to recursively go through folders

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
 
             # Check that viewbox' width and height are equal
             if [[ $vbW != $vbH ]] ; then
-              errArr+=("$f has viewbox' width: $vbW and height: $vbH")
+              errArr+=("$f has viewbox -width: $vbW and -height: $vbH")
             fi
 
             # Check if normal width/height parameters exist and
@@ -68,7 +68,7 @@ jobs:
               w=${svgTags##*width=\"}
               w=${h%%\"*}
               if [[ $w != $vbW ]] ; then
-                errArr+=("$f has width: $w but viewbox width: $vbW")
+                errArr+=("$f has width: $w but viewbox-width: $vbW")
               fi
             fi
 
@@ -77,7 +77,7 @@ jobs:
               h=${svgTags##*height=\"}
               h=${h%%\"*}
               if [[ $h != $vbH ]] ; then
-                errArr+=("$f has height: $h but viewbox height: $vbH")
+                errArr+=("$f has height: $h but viewbox-height: $vbH")
               fi
             fi
             

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Test Square SVGs
 
 # Triggers the workflow on push / pull request events but only for the svg folder
@@ -66,7 +64,10 @@ jobs:
           done
           
           # Results
+          # If the error Array is not empty, print everything from it and error out
+          # Otherwise exit normally
           if [[ ${#errArr[@]} != 0 ]] ; then
+            echo "--------------------"
             for errMess in "${errArr[@]}"
             do
               echo $errMess

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
           done
       - name: Post results
         run: |
-          if [[ ${#errArr[@]} != 0 ] ; then
+          if [[ ${#errArr[@]} != 0 ]] ; then
             for errMess in "${errArr[@]}"
             do
               echo $errMess

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,9 +38,9 @@ jobs:
             # sets x, y, width, height params
             vbArr=($vbStr)
             x=${vbArr[0]}
-            y=$(vbArr[1]}
-            w=$(vbArr[2]}
-            h=$(vbArr[3]}
+            y=${vbArr[1]}
+            w=${vbArr[2]}
+            h=${vbArr[3]}
 
             # Check that x and y are 0
             if [[ $x != 0 || $y != 0 ]] ; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
             # Width comparison
             if [[ $svgTags == *width* ]] ; then
               w=${svgTags##*width=\"}
-              w=${h%%\"*}
+              w=${w%%\"*}
               if [[ $w != $vbW ]] ; then
                 errArr+=("$f has width: $w but viewbox-width: $vbW")
               fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  Test-SVGs:
     runs-on: ubuntu-latest
 
     steps:
@@ -31,6 +31,12 @@ jobs:
           for f in ./**/*.svg 
           do
             echo "Checking '$f'"
+            
+            # Checking if file contains space in path
+            if [[ $f == *\ * ]] ; then
+              errArr+=("$f contains a space!")
+            fi
+            
             # Gets everything in between the viewBox quotes
             vbStr=$(cat $f)
             vbStr=${vbStr##*viewBox=\"}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
               errArr+=("$f is only one line!")
             fi
           done
+           if [[ ${#errArr[@]} != 0 ]] ; then echo "this should get hit" ; fi
       - name: Post results
         run: |
           if [[ ${#errArr[@]} != 0 ]] ; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,4 +66,4 @@ jobs:
             done
             exit 1
           fi
-          echo "No Errors!
+          echo "No Errors!"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,13 +23,14 @@ jobs:
       - name: Install Inkscape
         run: sudo apt install inkscape
 
-      - name: Check Viewbox parameters
+      - name: Check SVG validity
         run: |
           # Enables globstar to recursively go through folders
           shopt -s globstar
           errArr=()
           for f in ./**/*.svg 
           do
+            echo "Checking '$f'"
             # Gets everything in between the viewBox quotes
             vbStr=$(cat $f)
             vbStr=${vbStr##*viewBox=\"}
@@ -57,9 +58,8 @@ jobs:
               errArr+=("$f is only one line!")
             fi
           done
-           if [[ ${#errArr[@]} != 0 ]] ; then echo "this should get hit" ; fi
-      - name: Post results
-        run: |
+          
+          # Results
           if [[ ${#errArr[@]} != 0 ]] ; then
             for errMess in "${errArr[@]}"
             do

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Inkscape
-        run: apt install inkscape
+        run: sudo apt install inkscape
 
       - name: Check Viewbox parameters
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,69 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Test Square SVGs
+
+# Triggers the workflow on push / pull request events but only for the svg folder
+on:
+  push:
+    paths: svg/
+  pull_request:
+    paths: svg/
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Install Inkscape
+        run: apt install inkscape
+
+      - name: Check Viewbox parameters
+        run: |
+          # Enables globstar to recursively go through folders
+          shopt -s globstar
+          errArr=()
+          for f in ./**/*.svg 
+          do
+            # Gets everything in between the viewBox quotes
+            vbStr=$(cat $f)
+            vbStr=${vbStr##*viewBox=\"}
+            vbStr=${vbStr%%\"*}
+
+            # sets x, y, width, height params
+            vbArr=($vbStr)
+            x=${vbArr[0]}
+            y=$(vbArr[1]}
+            w=$(vbArr[2]}
+            h=$(vbArr[3]}
+
+            # Check that x and y are 0
+            if [[ $x != 0 || $y != 0 ]] ; then
+              errArr+=("$f has x: $x and y: $y")
+            fi
+
+            # Check that width and height are equal
+            if [[ $w != $h ]] ; then
+              errArr+=("$f has width: $w and height: $h")
+            fi
+            
+            # Check that svg is not 1 line
+            if [[ $(wc -l < $f) == 0 ]] ; then
+              errArr+=("$f is only one line!")
+            fi
+          done
+      - name: Post results
+        run: |
+          if [[ ${#errArr[@]} != 0 ] ; then
+            for errMess in "${errArr[@]}"
+            do
+              echo $errMess
+            done
+            exit 1
+          fi
+          echo "No Errors!

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Test Square SVGs
+name: Test SVGs
 
 # Triggers the workflow on push / pull request events but only for the svg folder
 on:
@@ -42,19 +42,43 @@ jobs:
 
             # sets x, y, width, height params
             vbArr=($vbStr)
-            x=${vbArr[0]}
-            y=${vbArr[1]}
-            w=${vbArr[2]}
-            h=${vbArr[3]}
+            vbX=${vbArr[0]}
+            vbY=${vbArr[1]}
+            vbW=${vbArr[2]}
+            vbH=${vbArr[3]}
 
-            # Check that x and y are 0
-            if [[ $x != 0 || $y != 0 ]] ; then
-              errArr+=("$f has x: $x and y: $y")
+            # Check that viewbox' x and y are 0
+            if [[ $vbX != 0 || $vbY != 0 ]] ; then
+              errArr+=("$f has viewBox' x: $vbX and y: $vbY")
             fi
 
-            # Check that width and height are equal
-            if [[ $w != $h ]] ; then
-              errArr+=("$f has width: $w and height: $h")
+            # Check that viewbox' width and height are equal
+            if [[ $vbW != $vbH ]] ; then
+              errArr+=("$f has viewbox' width: $vbW and height: $vbH")
+            fi
+
+            # Check if normal width/height parameters exist and
+            # if yes, compare them with viewBox height/width
+            svgTags=$(cat $f)
+            svgTags=${svgTags##*\<svg}
+            svgTags=${svgTags%%\>*}
+            
+            # Width comparison
+            if [[ $svgTags == *width* ]] ; then
+              w=${svgTags##*width=\"}
+              w=${h%%\"*}
+              if [[ $w != $vbW ]] ; then
+                errArr+=("$f has width: $w but viewbox width: $vbW")
+              fi
+            fi
+
+            # Height comparison
+            if [[ $svgTags == *height* ]] ; then
+              h=${svgTags##*height=\"}
+              h=${h%%\"*}
+              if [[ $h != $vbH ]] ; then
+                errArr+=("$f has height: $h but viewbox height: $vbH")
+              fi
             fi
             
             # Check that svg is not 1 line


### PR DESCRIPTION
This adds a CI that's run whenever a commit gets created (either via PRs or normal push) that changes the `svg` folder in any way.
It checks and errors out on the following:
- if x and y of an svg's viewbox are not 0
- if width and height of an svg's viewbox are not equal
- if svg file contains spaces
- if svg file is only one line